### PR TITLE
Session managementAdding route protection for authenticated pages

### DIFF
--- a/frontend/src/components/auth/AuthContext.jsx
+++ b/frontend/src/components/auth/AuthContext.jsx
@@ -1,10 +1,11 @@
-import {createContext, useState, useContext, useEffect} from "react";
+import {createContext, useState, useContext, useEffect, useRef} from "react";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "../../api/supabaseClient";
 const AuthContext = createContext();
 
 export const AuthContextProvider = ({ children }) => {
     const [session, setSession] = useState(undefined);
+    const sessionRef = useRef(null);
 
     
     
@@ -49,17 +50,19 @@ export const AuthContextProvider = ({ children }) => {
             console.error("Error logging out: ", error);
             return {success: false, error};
         }
-        return {success: true, data,};
+        return {success: true};
     }
     
     
     useEffect(() =>{
         supabase.auth.getSession().then(({data: {session}}) => {
         setSession(session);
+        sessionRef.current = session;
         });
 
         supabase.auth.onAuthStateChange((_event, session) => {
             setSession(session);
+            sessionRef.current = session;
         });
     }, []);
     

--- a/frontend/src/components/auth/PrivateRoute.jsx
+++ b/frontend/src/components/auth/PrivateRoute.jsx
@@ -1,0 +1,18 @@
+import { Navigate } from "react-router-dom";
+import { UserAuth } from "./AuthContext";
+
+const PrivateRoute = ({ children }) => {
+    const { session } = UserAuth();
+
+    if (session === undefined) {
+        return null; // still loading, don't flash anything
+    }
+
+    if (!session) {
+        return <Navigate to="/login" />;
+    }
+
+    return children;
+};
+
+export default PrivateRoute;

--- a/frontend/src/routes/router.jsx
+++ b/frontend/src/routes/router.jsx
@@ -5,28 +5,28 @@ import Login from "../pages/Login";
 import DoctorView from "../pages/DoctorLandingView";
 import PatientView from "../pages/PatientLandingView";
 import PatientProfileView from "../pages/PatientProfileView";
-
 import WeeklyReportView from "../pages/WeeklyReportView";
 import HistoryView from "../pages/HistoryView";
 import CheckInView from "../pages/CheckInView";
 import LogoutTest from "../pages/logoutTest";
+import PrivateRoute from "../components/auth/PrivateRoute";
 
 import DoctorCheckInsView from "../pages/DoctorCheckInsView";
 import DoctorAppointmentsView from "../pages/DoctorAppointmentsView";
 import DoctorReportsView from "../pages/DoctorReportsView";
 
 export const router = createBrowserRouter([
-    { path: "/", element: <App /> },
-    { path: "/signup", element: <Signup /> },
-    { path: "/login", element: <Login /> },
-    { path: "/doctor", element: <DoctorView /> },
-    { path: "/doctor/check-ins", element: <DoctorCheckInsView /> },
-    { path: "/doctor/appointments", element: <DoctorAppointmentsView /> },
-    { path: "/doctor/reports", element: <DoctorReportsView /> },
-    { path: "/patient", element: <PatientView /> },
-    { path: "/patient-profile", element: <PatientProfileView /> },
-    { path: "/weekly-report", element: <WeeklyReportView /> },
-    { path: "/history", element: <HistoryView /> },
-    { path: "/check-in", element: <CheckInView /> },
-    { path: "/logoutTest", element: <LogoutTest /> },
+{path: "/", element: <App />},
+    {path: "/signup/:role", element: <Signup />},
+    {path: "/login", element: <Login />},
+    {path: "/doctor", element: <PrivateRoute><DoctorView /></PrivateRoute>},
+    {path: "/doctor/check-ins", element: <PrivateRoute><DoctorCheckInsView /></PrivateRoute>},
+    {path: "/doctor/appointments", element: <PrivateRoute><DoctorAppointmentsView /></PrivateRoute>},
+    {path: "/doctor/reports", element: <PrivateRoute><DoctorReportsView /></PrivateRoute>},
+    {path: "/patient", element: <PrivateRoute><PatientView /></PrivateRoute>},
+    {path: "/patient-profile", element: <PrivateRoute><PatientProfileView /></PrivateRoute>},
+    {path: "/weekly-report", element: <PrivateRoute><WeeklyReportView /></PrivateRoute>},
+    {path: "/history", element: <PrivateRoute><HistoryView /></PrivateRoute>},
+    {path: "/check-in", element: <PrivateRoute><CheckInView /></PrivateRoute>},
+    {path: "/logoutTest", element: <PrivateRoute><LogoutTest /></PrivateRoute>},
 ]);


### PR DESCRIPTION
This adds a `PrivateRoute` component which checks for a Supabase session, and if there is no session, it will redirect unauthenticated users to the `/login` page.  This puts all protected routes (patient, doctor, profile, and so on.  It fixes the `logoutUser` bug, where it referended a `data` variable that was not defined, and it added in a `sessionRef` for better session tracking.  Please merge this BEFORE the session-timeout branch