### PR TITLE
Added an alert system for high risk check in submissions

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -13,6 +13,7 @@ import checkInRoutes from "./routes/checkIns.js";
 import checkInResponseRoutes from "./routes/checkInResponses.js";
 import questionRoutes from "./routes/questions.js";
 import attachmentRoutes from "./routes/attachments.js";
+import alertRoutes from "./routes/alerts.js";
 
 dotenv.config();
 
@@ -40,6 +41,7 @@ app.use("/api/check-ins", checkInRoutes);
 app.use("/api/check-in-responses", checkInResponseRoutes);
 app.use("/api/questions", questionRoutes);
 app.use("/api/attachments", attachmentRoutes);
+app.use("/api/alerts", alertRoutes);
 
 // 404 handler
 app.use("*", (req, res) => {

--- a/backend/src/controllers/alertController.js
+++ b/backend/src/controllers/alertController.js
@@ -1,0 +1,65 @@
+import { httpResponse } from "../utils/httpResponse.js";
+import { AlertService } from "../services/alertService.js";
+
+export class AlertController {
+  static async getAlertsByProviderId(req, res, next) {
+    try {
+      const { providerId } = req.params;
+      const alerts = await AlertService.getAlertsByProviderId(providerId);
+      httpResponse.success(res, alerts, 200, "Alerts retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getNewAlertsByProviderId(req, res, next) {
+    try {
+      const { providerId } = req.params;
+      const alerts = await AlertService.getNewAlertsByProviderId(providerId);
+      httpResponse.success(res, alerts, 200, "New alerts retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getAlertsByPatientId(req, res, next) {
+    try {
+      const { patientId } = req.params;
+      const alerts = await AlertService.getAlertsByPatientId(patientId);
+      httpResponse.success(res, alerts, 200, "Alerts for patient retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getAlertById(req, res, next) {
+    try {
+      const { id } = req.params;
+      const alert = await AlertService.getAlertById(id);
+
+      if (!alert) {
+        return httpResponse.notFound(res, "Alert not found");
+      }
+
+      httpResponse.success(res, alert, 200, "Alert retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async updateAlertStatus(req, res, next) {
+    try {
+      const { id } = req.params;
+      const { status } = req.body;
+
+      if (!status || !["new", "reviewed", "dismissed"].includes(status)) {
+        return httpResponse.badRequest(res, "Valid status is required (new, reviewed, dismissed)");
+      }
+
+      const updatedAlert = await AlertService.updateAlertStatus(id, status);
+      httpResponse.success(res, updatedAlert, 200, "Alert status updated successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/backend/src/routes/alerts.js
+++ b/backend/src/routes/alerts.js
@@ -1,0 +1,13 @@
+import express from "express";
+import { AlertController } from "../controllers/alertController.js";
+import { asyncHandler } from "../middleware/errorHandler.js";
+
+const router = express.Router();
+
+router.get("/provider/:providerId", asyncHandler(AlertController.getAlertsByProviderId));
+router.get("/provider/:providerId/new", asyncHandler(AlertController.getNewAlertsByProviderId));
+router.get("/patient/:patientId", asyncHandler(AlertController.getAlertsByPatientId));
+router.get("/:id", asyncHandler(AlertController.getAlertById));
+router.patch("/:id/status", asyncHandler(AlertController.updateAlertStatus));
+
+export default router;

--- a/backend/src/services/alertService.js
+++ b/backend/src/services/alertService.js
@@ -1,0 +1,177 @@
+import { supabase } from "../supabaseAdminClient.js";
+
+// Question UUIDs that trigger critical alerts if scored at max value of 4
+const CRITICAL_QUESTION_IDS = [
+  "41df571a-f9c2-448f-9809-a65331dab392", // Tremor severity
+  "b2dfbfd8-63ce-4ffc-a5ef-3fa1ef22a9b8", // Balance issues / near-falls
+  "a9dab3f6-e206-4b2a-b56f-643cc4c12c86", // Medication breakthrough
+];
+
+const CRITICAL_SCORE = 4;                           // This is currently the max score for any of our scored questions
+const HIGH_TOTAL_THRESHOLD = 25;        // This can be adjusted, but seems like a decent starting point
+const CRITICAL_TOTAL_THRESHOLD = 30; // This leaves us with 10 points of room with our current number of questions 
+
+export class AlertService {
+
+  // Evaluate the completed check-in
+  static async evaluateCheckIn(checkInId, responses) {
+    const alerts = [];
+
+    // Get the check-in to find the patient_id
+    const { data: checkIn, error: checkInError } = await supabase
+      .from("check_ins")
+      .select("patient_id")
+      .eq("id", checkInId)
+      .single();
+
+    if (checkInError) throw checkInError;
+
+    // Find the provider assigned to the patient
+    const { data: providerPatient, error: ppError } = await supabase
+      .from("provider_patients")
+      .select("provider_id")
+      .eq("patient_id", checkIn.patient_id)
+      .eq("status", "active")
+      .limit(1)
+      .single();
+
+    if (ppError || !providerPatient) {
+      console.warn(`No active provider found for patient ${checkIn.patient_id}, skipping alert generation`);
+      return [];
+    }
+
+    const providerId = providerPatient.provider_id;
+
+    // Get question details
+    const questionIds = responses
+      .filter(r => r.question_id)
+      .map(r => r.question_id);
+
+    const { data: questions, error: qError } = await supabase
+      .from("questions")
+      .select("id, question_text, question_type")
+      .in("id", questionIds);
+
+    if (qError) throw qError;
+
+    const questionMap = {};
+    questions.forEach(q => { questionMap[q.id] = q; });
+
+    // Check individual responses to critical questions
+    for (const response of responses) {
+      if (
+        CRITICAL_QUESTION_IDS.includes(response.question_id) &&
+        response.numeric_value != null &&
+        response.numeric_value >= CRITICAL_SCORE
+      ) {
+        const question = questionMap[response.question_id];
+        alerts.push({
+          patient_id: checkIn.patient_id,
+          provider_id: providerId,
+          check_in_id: checkInId,
+          alert_type: "critical_single_response",
+          severity: "critical",
+          message: `Patient scored ${response.numeric_value}/4 on: "${question?.question_text || "Unknown question"}"`,
+          question_id: response.question_id,
+          score_value: response.numeric_value,
+          total_score: null,
+        });
+      }
+    }
+
+    // Check total score
+    const totalScore = responses.reduce((sum, r) => {
+      return sum + (r.numeric_value != null ? r.numeric_value : 0);
+    }, 0);
+
+    if (totalScore >= HIGH_TOTAL_THRESHOLD) {
+      const severity = totalScore >= CRITICAL_TOTAL_THRESHOLD ? "critical" : "warning";
+      alerts.push({
+        patient_id: checkIn.patient_id,
+        provider_id: providerId,
+        check_in_id: checkInId,
+        alert_type: "high_total_score",
+        severity,
+        message: `Patient total symptom score: ${totalScore}/40`,
+        question_id: null,
+        score_value: null,
+        total_score: totalScore,
+      });
+    }
+
+    // Insert alerts if needed
+    if (alerts.length > 0) {
+      const { data, error } = await supabase
+        .from("alerts")
+        .insert(alerts)
+        .select();
+
+      if (error) throw error;
+      return data;
+    }
+
+    return [];
+  }
+
+  static async getAlertsByProviderId(providerId) {
+    const { data, error } = await supabase
+      .from("alerts")
+      .select("*")
+      .eq("provider_id", providerId)
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return data;
+  }
+
+  static async getAlertsByPatientId(patientId) {
+    const { data, error } = await supabase
+      .from("alerts")
+      .select("*")
+      .eq("patient_id", patientId)
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return data;
+  }
+
+  static async getAlertById(id) {
+    const { data, error } = await supabase
+      .from("alerts")
+      .select("*")
+      .eq("id", id)
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  static async updateAlertStatus(id, status) {
+    const updateData = { status };
+    if (status === "reviewed" || status === "dismissed") {
+      updateData.reviewed_at = new Date().toISOString();
+    }
+
+    const { data, error } = await supabase
+      .from("alerts")
+      .update(updateData)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  static async getNewAlertsByProviderId(providerId) {
+    const { data, error } = await supabase
+      .from("alerts")
+      .select("*")
+      .eq("provider_id", providerId)
+      .eq("status", "new")
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return data;
+  }
+}

--- a/backend/src/services/checkInResponseService.js
+++ b/backend/src/services/checkInResponseService.js
@@ -1,4 +1,5 @@
 import { supabase } from "../supabaseAdminClient.js";
+import { AlertService } from "./alertService.js";
 
 export class CheckInResponseService {
   static async getAllCheckInResponses() {
@@ -59,6 +60,17 @@ export class CheckInResponseService {
       .select();
     
     if (error) throw error;
+
+    // Evaluate alert thresholds after responses are saved
+    if (data && data.length > 0) {
+      try {
+        const checkInId = data[0].check_in_id;
+        await AlertService.evaluateCheckIn(checkInId, data);
+      } catch (alertError) {
+        console.error("Alert evaluation failed (responses were still saved):", alertError);
+      }
+    }
+
     return data;
   }
 

--- a/frontend/src/components/auth/AuthContext.jsx
+++ b/frontend/src/components/auth/AuthContext.jsx
@@ -2,10 +2,12 @@ import {createContext, useState, useContext, useEffect, useRef, useCallback} fro
 import { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "../../api/supabaseClient";
 import SessionTimeoutWarning from "./SessionTimeoutWarning";
+import ProfileService from "../../services/profileService";
 const AuthContext = createContext();
 
 export const AuthContextProvider = ({ children }) => {
     const [session, setSession] = useState(undefined);
+    const [profile, setProfile] = useState(null);
     const sessionRef = useRef(null);
     const TIMEOUT_DURATION = 15 * 60 * 1000; // 15 min timer. Use `30 * 1000` for 30 second testing
     const timeoutRef = useRef(null);
@@ -114,20 +116,39 @@ export const AuthContextProvider = ({ children }) => {
         return {success: true, data};
     }
 
+    const fetchProfile = async (authUserId) => {
+        try {
+            const result = await ProfileService.getProfileByAuthUserId(authUserId);
+            const profileData = result.data ?? result;
+            setProfile(profileData);
+        } catch (err) {
+            console.error("Failed to fetch profile:", err);
+            setProfile(null);
+        }
+    };
+
     useEffect(() =>{
         supabase.auth.getSession().then(({data: {session}}) => {
             setSession(session);
             sessionRef.current = session;
+            if (session?.user?.id) {
+                fetchProfile(session.user.id);
+            }
         });
 
         supabase.auth.onAuthStateChange((_event, session) => {
             setSession(session);
             sessionRef.current = session;
+            if (session?.user?.id) {
+                fetchProfile(session.user.id);
+            } else {
+                setProfile(null);
+            }
         });
     }, []);
 
     return (
-        <AuthContext.Provider value={{session, signUpNewUser, loginUser, logoutUser, showTimeoutWarning, extendSession}}>
+        <AuthContext.Provider value={{session, profile, signUpNewUser, loginUser, logoutUser, showTimeoutWarning, extendSession}}>
         {showTimeoutWarning && <SessionTimeoutWarning />}
         {children}
         </AuthContext.Provider>

--- a/frontend/src/pages/CheckInView.jsx
+++ b/frontend/src/pages/CheckInView.jsx
@@ -45,7 +45,7 @@ const paginateQuestions = (questions) => [
 ];
 
 const CheckInView = () => {
-  const { session } = UserAuth();
+  const { session, profile } = UserAuth();
 
   const [questions, setQuestions] = useState([]);
   const [pages, setPages] = useState([[], [], []]);
@@ -122,7 +122,7 @@ const CheckInView = () => {
   const handleSubmit = async () => {
     if (!isAllComplete) return;
 
-    const patientId = session?.user?.id;
+    const patientId = profile?.id;
 
     if (!patientId) {
       setSnackbar({
@@ -141,7 +141,8 @@ const CheckInView = () => {
 
       const responses = questions.map((q) => ({
         question_id: q.id,
-        response_value: answers[q.id],
+        numeric_value: q.question_type === "scale" ? answers[q.id] : null,
+        text_value: q.question_type === "free_text" ? answers[q.id] : null,
       }));
 
       await CheckInService.submitResponses(checkInId, responses);


### PR DESCRIPTION
Created some new files:
- `backend/src/services/alertService.js` which is the primary alert logic.  This reviews the check in responses after they are submitted and creates an alert when the overall score is over 25/40 (it creates a warning), 30/40 (it creates a critical alert), and if a patient scores a 4/4 on some critical questions.  Specifically the tremor severity, balance issues, or the question on if symptoms broke through.
- `backend/src/controllers/alertController.js` is a REST controller for fielding and updating the alerts.
- `backend/src/routes/alerts.js` which is the API routes for the alert.

Some files were then modified:
- `backend/src/app.js` was updated to handle the new `/api/alerts` route.
- `backend/src/services/checkInResponseService.js` was updated so that after the responses are inserted, `AlertService.evaluateCheckIn()` is called.  This was placed inside of a try/catch to try and provide proper alerting to failures, so that they will not break a check-in submission.
- `frontend/src/components/auth/AuthContext/jsx` was updated to fetch the profile of the users from the backend when a session is first started.  This is used to make the profile `id` available to all components.
- `frontend/src/pages/CheckInView.jsx` needed to be updated to fix two bugs.  Specifically, I needed to use `profile.id` instead of `session.user.id`, and `numeric_value`/`text_value` instead of `response_value`.

Doing the above required that the Supabase database get updated as well.  A new `alerts` table was created in Supabase.  It has columns for the patient, provider, check-in, alert type, severity, message, status, and timestamps.

How to test:
- First, ensure that a patient is assigned to a provider in the `provider_patients` table.  You will need to insert a row, using the `id` column from the profiles table for both the patient and the provider.  Set their status to `active`, and save it.
- Next, log in as the patient, submit a check-in with some high scores.  Specifically a score of 4 on one of the critical questions, and/or an overall score over 25 or 30 depending on which type of alert you want to generate.
- Lastly, query with `GET /api/alerts/provider/{provider_profile_id} to see the alert that is generated.  I specifically ran it like this on my system: `curl http://localhost:4000/api/alerts/provider/92f18cc8-5715-453f-a085-7edd24b41ce5 2>/dev/null | python3 -m json.tool`.

Lastly, please note that the Dr. dashboard is NOT currently set up to use these alerts.  That will need a different PR.