### PR TITLE
Add provider check-in history with patient authorization

### DIFF
--- a/backend/src/controllers/checkInController.js
+++ b/backend/src/controllers/checkInController.js
@@ -82,4 +82,29 @@ export class CheckInController {
       next(error);
     }
   }
+
+  static async getCheckInsForProvider(req, res, next) {
+    try {
+      const { providerId } = req.params;
+      const checkIns = await CheckInService.getCheckInsForProvider(providerId);
+      httpResponse.success(res, checkIns, 200, "Provider check-ins retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getCheckInsByPatientIdForProvider(req, res, next) {
+    try {
+      const { providerId, patientId } = req.params;
+      const checkIns = await CheckInService.getCheckInsByPatientIdForProvider(providerId, patientId);
+
+      if (checkIns === null) {
+        return httpResponse.unauthorized(res, "This patient is not assigned to you");
+      }
+
+      httpResponse.success(res, checkIns, 200, "Patient check-ins retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/backend/src/routes/checkIns.js
+++ b/backend/src/routes/checkIns.js
@@ -5,9 +5,11 @@ import { asyncHandler } from "../middleware/errorHandler.js";
 const router = express.Router();
 
 router.get("/", asyncHandler(CheckInController.getAllCheckIns));
-router.get("/:id", asyncHandler(CheckInController.getCheckInById));
+router.get("/provider/:providerId", asyncHandler(CheckInController.getCheckInsForProvider));
+router.get("/provider/:providerId/patient/:patientId", asyncHandler(CheckInController.getCheckInsByPatientIdForProvider));
 router.get("/patient/:patientId", asyncHandler(CheckInController.getCheckInsByPatientId));
 router.get("/status/:status", asyncHandler(CheckInController.getCheckInsByStatus));
+router.get("/:id", asyncHandler(CheckInController.getCheckInById));
 router.post("/", asyncHandler(CheckInController.createCheckIn));
 router.put("/:id", asyncHandler(CheckInController.updateCheckIn));
 router.delete("/:id", asyncHandler(CheckInController.deleteCheckIn));

--- a/backend/src/services/checkInService.js
+++ b/backend/src/services/checkInService.js
@@ -84,7 +84,65 @@ export class CheckInService {
       .from("check_ins")
       .select("*")
       .eq("status", status);
-    
+
+    if (error) throw error;
+    return data;
+  }
+
+  static async getCheckInsForProvider(providerId) {
+    // Get active patient IDs for this provider
+    const { data: assignments, error: assignError } = await supabase
+      .from("provider_patients")
+      .select("patient_id")
+      .eq("provider_id", providerId)
+      .eq("status", "active");
+
+    if (assignError) throw assignError;
+
+    const patientIds = assignments.map((a) => a.patient_id);
+    if (patientIds.length === 0) return [];
+
+    // Fetch check-ins for those patients with patient profile info and responses
+    const { data, error } = await supabase
+      .from("check_ins")
+      .select(
+        "*, patient:profiles!check_ins_patient_id_fkey(id, first_name, last_name), check_in_responses(numeric_value, text_value, question:questions(question_text, question_type))"
+      )
+      .in("patient_id", patientIds)
+      .order("check_in_date", { ascending: false });
+
+    if (error) throw error;
+    return data;
+  }
+
+  static async isProviderForPatient(providerId, patientId) {
+    const { data, error } = await supabase
+      .from("provider_patients")
+      .select("id")
+      .eq("provider_id", providerId)
+      .eq("patient_id", patientId)
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (error) throw error;
+    return !!data;
+  }
+
+  static async getCheckInsByPatientIdForProvider(providerId, patientId) {
+    const isProvider = await CheckInService.isProviderForPatient(
+      providerId,
+      patientId
+    );
+    if (!isProvider) return null; // signals unauthorized
+
+    const { data, error } = await supabase
+      .from("check_ins")
+      .select(
+        "*, check_in_responses(numeric_value, text_value, question:questions(question_text, question_type))"
+      )
+      .eq("patient_id", patientId)
+      .order("check_in_date", { ascending: false });
+
     if (error) throw error;
     return data;
   }

--- a/frontend/src/pages/DoctorCheckInsView.jsx
+++ b/frontend/src/pages/DoctorCheckInsView.jsx
@@ -1,25 +1,101 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Box, Typography, Button, TextField, MenuItem, Chip, Divider } from "@mui/material";
+import {
+  Box,
+  Typography,
+  Button,
+  TextField,
+  MenuItem,
+  Chip,
+  Divider,
+  CircularProgress,
+  Alert,
+  Collapse,
+  LinearProgress,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import { UserAuth } from "../components/auth/AuthContext";
+import CheckInService from "../services/checkInService";
 
-const mockCheckIns = [
-  { id: 1, patient: "Alice Johnson", date: "2026-04-16", status: "Critical", summary: "Severe tremors, difficulty walking" },
-  { id: 2, patient: "Alice Johnson", date: "2026-04-15", status: "Stable",   summary: "Mild tremors, slept well" },
-  { id: 3, patient: "Bob Smith",     date: "2026-04-16", status: "Stable",   summary: "No notable symptoms" },
-  { id: 4, patient: "Bob Smith",     date: "2026-04-14", status: "Stable",   summary: "Slight stiffness in morning" },
-  { id: 5, patient: "Carol White",   date: "2026-04-15", status: "Pending",  summary: "No submission" },
-];
+const getStatus = (checkIn) => {
+  if (checkIn.status === "complete") {
+    const responses = checkIn.check_in_responses || [];
+    const total = responses.reduce((sum, r) => sum + (r.numeric_value || 0), 0);
+    if (total >= 25) return "Critical";
+    return "Stable";
+  }
+  if (checkIn.status === "in_progress") return "Pending";
+  return "Pending";
+};
+
+const getSummary = (checkIn) => {
+  const responses = checkIn.check_in_responses || [];
+  if (responses.length === 0) return "No responses submitted";
+
+  const high = responses
+    .filter((r) => r.numeric_value != null && r.numeric_value >= 3)
+    .map((r) => r.question?.question_text)
+    .filter(Boolean);
+
+  const freeText = responses.find((r) => r.question?.question_type === "free_text");
+
+  if (high.length > 0) {
+    return `High: ${high.join(", ")}`;
+  }
+  if (freeText?.text_value) {
+    return freeText.text_value;
+  }
+  return "No notable symptoms";
+};
 
 const statusColors = { Critical: "error", Stable: "success", Pending: "warning" };
 
 const DoctorCheckInsView = () => {
   const navigate = useNavigate();
-  const patients = ["All Patients", "Alice Johnson", "Bob Smith", "Carol White"];
+  const { profile } = UserAuth();
+  const [checkIns, setCheckIns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [selectedPatient, setSelectedPatient] = useState("All Patients");
+  const [expandedId, setExpandedId] = useState(null);
 
-  const filtered = selectedPatient === "All Patients"
-    ? mockCheckIns
-    : mockCheckIns.filter(c => c.patient === selectedPatient);
+  useEffect(() => {
+    const fetchCheckIns = async () => {
+      if (!profile?.id) return;
+      try {
+        setLoading(true);
+        const result = await CheckInService.getCheckInsForProvider(profile.id);
+        setCheckIns(result.data || []);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCheckIns();
+  }, [profile?.id]);
+
+  const patientNames = [
+    ...new Set(
+      checkIns.map(
+        (c) =>
+          c.patient
+            ? `${c.patient.first_name} ${c.patient.last_name}`
+            : "Unknown"
+      )
+    ),
+  ];
+  const patients = ["All Patients", ...patientNames];
+
+  const filtered =
+    selectedPatient === "All Patients"
+      ? checkIns
+      : checkIns.filter(
+          (c) =>
+            c.patient &&
+            `${c.patient.first_name} ${c.patient.last_name}` === selectedPatient
+        );
 
   return (
     <Box sx={{ maxWidth: 900, mx: "auto", p: { xs: 2, md: 3 } }}>
@@ -27,7 +103,7 @@ const DoctorCheckInsView = () => {
         onClick={() => navigate("/doctor")}
         sx={{ textTransform: "none", color: "#185FA5", mb: 2, pl: 0 }}
       >
-        ← Back to Dashboard
+        &larr; Back to Dashboard
       </Button>
 
       <Typography variant="h5" fontWeight={600} gutterBottom>
@@ -37,53 +113,255 @@ const DoctorCheckInsView = () => {
         View and filter all submitted check-ins across your patients.
       </Typography>
 
-      <TextField
-        select
-        label="Filter by patient"
-        value={selectedPatient}
-        onChange={(e) => setSelectedPatient(e.target.value)}
-        size="small"
-        sx={{ minWidth: 220, mb: 3 }}
-      >
-        {patients.map((p) => (
-          <MenuItem key={p} value={p}>{p}</MenuItem>
-        ))}
-      </TextField>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
 
-      <Divider sx={{ mb: 2 }} />
-
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-        {filtered.map((checkIn) => (
-          <Box
-            key={checkIn.id}
-            sx={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              border: "0.5px solid",
-              borderColor: "divider",
-              borderRadius: "12px",
-              p: 2,
-              backgroundColor: "background.paper",
-            }}
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
+          <TextField
+            select
+            label="Filter by patient"
+            value={selectedPatient}
+            onChange={(e) => setSelectedPatient(e.target.value)}
+            size="small"
+            sx={{ minWidth: 220, mb: 3 }}
           >
-            <Box>
-              <Typography variant="body1" fontWeight={500}>{checkIn.patient}</Typography>
-              <Typography variant="body2" color="text.secondary">{checkIn.date}</Typography>
-              <Typography variant="body2" sx={{ mt: 0.5 }}>{checkIn.summary}</Typography>
-            </Box>
-            <Chip
-              label={checkIn.status}
-              color={statusColors[checkIn.status]}
-              size="small"
-              sx={{ borderRadius: "8px", fontWeight: 500 }}
-            />
+            {patients.map((p) => (
+              <MenuItem key={p} value={p}>
+                {p}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          <Divider sx={{ mb: 2 }} />
+
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            {filtered.map((checkIn) => {
+              const status = getStatus(checkIn);
+              const isExpanded = expandedId === checkIn.id;
+              const patientName = checkIn.patient
+                ? `${checkIn.patient.first_name} ${checkIn.patient.last_name}`
+                : "Unknown";
+              const responses = checkIn.check_in_responses || [];
+              const scaleResponses = responses.filter(
+                (r) => r.question?.question_type === "scale"
+              );
+              const freeTextResponses = responses.filter(
+                (r) => r.question?.question_type === "free_text"
+              );
+              const totalScore = scaleResponses.reduce(
+                (sum, r) => sum + (r.numeric_value || 0),
+                0
+              );
+              const maxScore = scaleResponses.length * 4;
+
+              return (
+                <Box
+                  key={checkIn.id}
+                  sx={{
+                    border: "0.5px solid",
+                    borderColor: isExpanded ? "primary.main" : "divider",
+                    borderRadius: "12px",
+                    backgroundColor: "background.paper",
+                    overflow: "hidden",
+                    transition: "border-color 0.2s",
+                  }}
+                >
+                  <Box
+                    onClick={() =>
+                      setExpandedId(isExpanded ? null : checkIn.id)
+                    }
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      p: 2,
+                      cursor: "pointer",
+                      "&:hover": { backgroundColor: "action.hover" },
+                    }}
+                  >
+                    <Box>
+                      <Typography variant="body1" fontWeight={500}>
+                        {patientName}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {checkIn.check_in_date}
+                      </Typography>
+                      <Typography variant="body2" sx={{ mt: 0.5 }}>
+                        {getSummary(checkIn)}
+                      </Typography>
+                    </Box>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                      }}
+                    >
+                      <Chip
+                        label={status}
+                        color={statusColors[status]}
+                        size="small"
+                        sx={{ borderRadius: "8px", fontWeight: 500 }}
+                      />
+                      {isExpanded ? (
+                        <ExpandLessIcon color="action" />
+                      ) : (
+                        <ExpandMoreIcon color="action" />
+                      )}
+                    </Box>
+                  </Box>
+
+                  <Collapse in={isExpanded}>
+                    <Divider />
+                    <Box sx={{ p: 2 }}>
+                      {responses.length === 0 ? (
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                        >
+                          No responses recorded for this check-in.
+                        </Typography>
+                      ) : (
+                        <>
+                          {maxScore > 0 && (
+                            <Box sx={{ mb: 2 }}>
+                              <Box
+                                sx={{
+                                  display: "flex",
+                                  justifyContent: "space-between",
+                                  mb: 0.5,
+                                }}
+                              >
+                                <Typography
+                                  variant="body2"
+                                  fontWeight={600}
+                                >
+                                  Overall Symptom Score
+                                </Typography>
+                                <Typography
+                                  variant="body2"
+                                  fontWeight={600}
+                                >
+                                  {totalScore} / {maxScore}
+                                </Typography>
+                              </Box>
+                              <LinearProgress
+                                variant="determinate"
+                                value={(totalScore / maxScore) * 100}
+                                color={
+                                  totalScore >= 25
+                                    ? "error"
+                                    : totalScore >= 15
+                                    ? "warning"
+                                    : "success"
+                                }
+                                sx={{
+                                  height: 8,
+                                  borderRadius: 4,
+                                }}
+                              />
+                            </Box>
+                          )}
+
+                          <Box
+                            sx={{
+                              display: "flex",
+                              flexDirection: "column",
+                              gap: 1.5,
+                            }}
+                          >
+                            {scaleResponses.map((r) => (
+                              <Box key={r.question?.question_text}>
+                                <Box
+                                  sx={{
+                                    display: "flex",
+                                    justifyContent: "space-between",
+                                    mb: 0.25,
+                                  }}
+                                >
+                                  <Typography variant="body2">
+                                    {r.question?.question_text}
+                                  </Typography>
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight={600}
+                                    color={
+                                      r.numeric_value >= 3
+                                        ? "error.main"
+                                        : "text.primary"
+                                    }
+                                  >
+                                    {r.numeric_value} / 4
+                                  </Typography>
+                                </Box>
+                                <LinearProgress
+                                  variant="determinate"
+                                  value={(r.numeric_value / 4) * 100}
+                                  color={
+                                    r.numeric_value >= 3
+                                      ? "error"
+                                      : r.numeric_value >= 2
+                                      ? "warning"
+                                      : "success"
+                                  }
+                                  sx={{
+                                    height: 6,
+                                    borderRadius: 3,
+                                  }}
+                                />
+                              </Box>
+                            ))}
+
+                            {freeTextResponses.map((r) => (
+                              <Box
+                                key={r.question?.question_text}
+                                sx={{
+                                  mt: 1,
+                                  p: 1.5,
+                                  backgroundColor: "grey.50",
+                                  borderRadius: "8px",
+                                }}
+                              >
+                                <Typography
+                                  variant="body2"
+                                  fontWeight={600}
+                                  sx={{ mb: 0.5 }}
+                                >
+                                  {r.question?.question_text}
+                                </Typography>
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                  sx={{ fontStyle: r.text_value ? "normal" : "italic" }}
+                                >
+                                  {r.text_value || "No response provided"}
+                                </Typography>
+                              </Box>
+                            ))}
+                          </Box>
+                        </>
+                      )}
+                    </Box>
+                  </Collapse>
+                </Box>
+              );
+            })}
+            {filtered.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                No check-ins found.
+              </Typography>
+            )}
           </Box>
-        ))}
-        {filtered.length === 0 && (
-          <Typography variant="body2" color="text.secondary">No check-ins found.</Typography>
-        )}
-      </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/frontend/src/services/checkInService.js
+++ b/frontend/src/services/checkInService.js
@@ -29,6 +29,20 @@ class CheckInService {
     if (!response.ok) throw new Error(data.message || "Failed to submit responses");
     return data;
   }
+
+  static async getCheckInsForProvider(providerId) {
+    const response = await fetch(`${BASE_URL}/check-ins/provider/${providerId}`);
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.message || "Failed to fetch provider check-ins");
+    return data;
+  }
+
+  static async getCheckInsByPatientForProvider(providerId, patientId) {
+    const response = await fetch(`${BASE_URL}/check-ins/provider/${providerId}/patient/${patientId}`);
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.message || "Failed to fetch patient check-ins");
+    return data;
+  }
 }
 
 export default CheckInService;


### PR DESCRIPTION
Doctors can now view check-in history for their assigned patients only. Check-in cards expand on click to show all questions and responses with score visualizations.