### PR TITLE
Add an in-app notification for providers for when a patient books an …

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -18,6 +18,7 @@ import appointmentRoutes from "./routes/appointments.js";
 import providerAvailabilityRoutes from "./routes/providerAvailability.js";
 import providerAvailabilityExceptionRoutes from "./routes/providerAvailabilityExceptions.js";
 import alertRoutes from "./routes/alerts.js";
+import notificationRoutes from "./routes/notifications.js";
 
 dotenv.config();
 
@@ -50,6 +51,7 @@ app.use("/api/appointments", appointmentRoutes);
 app.use("/api/provider-availability", providerAvailabilityRoutes);
 app.use("/api/provider-availability-exceptions", providerAvailabilityExceptionRoutes);
 app.use("/api/alerts", alertRoutes);
+app.use("/api/notifications", notificationRoutes);
 
 // 404 handler
 app.use("*", (req, res) => {

--- a/backend/src/controllers/notificationController.js
+++ b/backend/src/controllers/notificationController.js
@@ -1,0 +1,65 @@
+import { httpResponse } from "../utils/httpResponse.js";
+import { NotificationService } from "../services/notificationService.js";
+
+export class NotificationController {
+  static async getByRecipientId(req, res, next) {
+    try {
+      const { recipientId } = req.params;
+      const notifications = await NotificationService.getByRecipientId(recipientId);
+      httpResponse.success(res, notifications, 200, "Notifications retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getUnreadByRecipientId(req, res, next) {
+    try {
+      const { recipientId } = req.params;
+      const notifications = await NotificationService.getUnreadByRecipientId(recipientId);
+      httpResponse.success(res, notifications, 200, "Unread notifications retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getById(req, res, next) {
+    try {
+      const { id } = req.params;
+      const notification = await NotificationService.getById(id);
+
+      if (!notification) {
+        return httpResponse.notFound(res, "Notification not found");
+      }
+
+      httpResponse.success(res, notification, 200, "Notification retrieved successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async updateStatus(req, res, next) {
+    try {
+      const { id } = req.params;
+      const { status } = req.body;
+
+      if (!status || !["unread", "read", "dismissed"].includes(status)) {
+        return httpResponse.badRequest(res, "Valid status is required (unread, read, dismissed)");
+      }
+
+      const updated = await NotificationService.updateStatus(id, status);
+      httpResponse.success(res, updated, 200, "Notification status updated successfully");
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async markAllRead(req, res, next) {
+    try {
+      const { recipientId } = req.params;
+      const updated = await NotificationService.markAllRead(recipientId);
+      httpResponse.success(res, updated, 200, "All notifications marked as read");
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,13 @@
+import express from "express";
+import { NotificationController } from "../controllers/notificationController.js";
+import { asyncHandler } from "../middleware/errorHandler.js";
+
+const router = express.Router();
+
+router.get("/recipient/:recipientId", asyncHandler(NotificationController.getByRecipientId));
+router.get("/recipient/:recipientId/unread", asyncHandler(NotificationController.getUnreadByRecipientId));
+router.patch("/recipient/:recipientId/read-all", asyncHandler(NotificationController.markAllRead));
+router.get("/:id", asyncHandler(NotificationController.getById));
+router.patch("/:id/status", asyncHandler(NotificationController.updateStatus));
+
+export default router;

--- a/backend/src/services/appointmentService.js
+++ b/backend/src/services/appointmentService.js
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 import { supabase } from "../supabaseAdminClient.js";
 import { computeAvailableSlots } from "./availabilityService.js";
+import { NotificationService } from "./notificationService.js";
 
 const HORIZON_DAYS = 60;
 
@@ -74,6 +75,32 @@ export class AppointmentService {
       }
       throw error;
     }
+
+    // Notification for the provider about a new booking
+    try {
+      const { data: patient } = await supabase
+        .from("profiles")
+        .select("first_name, last_name")
+        .eq("id", patient_id)
+        .single();
+
+      const patientName = patient
+        ? `${patient.first_name} ${patient.last_name}`
+        : "A patient";
+
+      const startLocal = startUtc.toLocaleString(DateTime.DATETIME_MED);
+
+      await NotificationService.create({
+        recipient_id: provider_id,
+        sender_id: patient_id,
+        type: "appointment_booked",
+        message: `${patientName} booked an appointment for ${startLocal}`,
+        related_appointment_id: data.id,
+      });
+    } catch (notifError) {
+      console.error("Notification failed (appointment was still booked):", notifError);
+    }
+
     return data;
   }
 

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -1,0 +1,90 @@
+import { supabase } from "../supabaseAdminClient.js";
+
+export class NotificationService {
+
+  // Create documentation of the notification
+  static async create({ recipient_id, sender_id, type, message, related_appointment_id }) {
+    const { data, error } = await supabase
+      .from("notifications")
+      .insert([{
+        recipient_id,
+        sender_id: sender_id || null,
+        type,
+        message,
+        related_appointment_id: related_appointment_id || null,
+      }])
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  // Get all notifications for a user (starting with the newest)
+  static async getByRecipientId(recipientId) {
+    const { data, error } = await supabase
+      .from("notifications")
+      .select("*, sender:profiles!notifications_sender_id_fkey(id, first_name, last_name)")
+      .eq("recipient_id", recipientId)
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return data;
+  }
+
+  // Get the unread notifications for a user
+  static async getUnreadByRecipientId(recipientId) {
+    const { data, error } = await supabase
+      .from("notifications")
+      .select("*, sender:profiles!notifications_sender_id_fkey(id, first_name, last_name)")
+      .eq("recipient_id", recipientId)
+      .eq("status", "unread")
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return data;
+  }
+
+  // Get a single notification by ID
+  static async getById(id) {
+    const { data, error } = await supabase
+      .from("notifications")
+      .select("*, sender:profiles!notifications_sender_id_fkey(id, first_name, last_name)")
+      .eq("id", id)
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  // Mark a notification as read
+  static async updateStatus(id, status) {
+    const updateData = { status };
+    if (status === "read" || status === "dismissed") {
+      updateData.read_at = new Date().toISOString();
+    }
+
+    const { data, error } = await supabase
+      .from("notifications")
+      .update(updateData)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  // Mark all of the unread notifications as read for a user
+  static async markAllRead(recipientId) {
+    const { data, error } = await supabase
+      .from("notifications")
+      .update({ status: "read", read_at: new Date().toISOString() })
+      .eq("recipient_id", recipientId)
+      .eq("status", "unread")
+      .select();
+
+    if (error) throw error;
+    return data;
+  }
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -87,7 +87,8 @@ const { data: { user } } = await supabase.auth.getUser()
 | `provider_availability` | Weekly recurring availability template per provider | Provider (own), patients booking slots |
 | `provider_availability_exceptions` | One-off time-off / blocked ranges | Provider (own), patients booking slots |
 | `appointments` | Booked 1-hour slots between a patient and provider | Both sides of the relationship |
-
+| `notifications`| In-app alerts triggered by appointment events | Recipient user |
+  
 **Row Level Security (RLS)** is enabled on all tables. Users can only access data they are authorized to see.
 
 ---
@@ -902,6 +903,56 @@ CREATE UNIQUE INDEX appointments_unique_scheduled_slot
 Cancelled rows do not occupy the slot — rebooking after a cancellation is allowed.
 
 ---
+
+## Notifications
+In-app notifications are generated automatically when an appointment-related event occurs. Currently, a notification is created for the provider whenever a patient books an appointment. Notifications for cancellations and reschedules can be added in a future sprint.
+
+Notifications get created by the backend when booked.  They do not not need to be created manually.
+
+### Get All Notifications for a User
+```
+GET /api/notifications/recipient/:recipientId
+```
+Returns all notifications for the user, newest first. Includes the sender's name via a join on profiles.
+
+### Get Unread Notifications for a User
+```
+GET /api/notifications/recipient/:recipientId/unread
+```
+
+### Get a Single Notification
+```
+GET /api/notifications/:id
+```
+
+### Update Notification Status
+```
+PATCH /api/notifications/:id/status
+Content-Type: application/json
+{
+  "status": "read"   // "unread", "read", or "dismissed"
+}
+```
+
+### Mark All Notifications as Read
+```
+PATCH /api/notifications/recipient/:recipientId/read-all
+```
+
+### Schema
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid | Primary key |
+| `recipient_id` | uuid | FK → profiles, the user who receives the notification |
+| `sender_id` | uuid | FK → profiles, the user who triggered the event (nullable) |
+| `type` | text | `'appointment_booked'` \| `'appointment_cancelled'` \| `'appointment_rescheduled'` |
+| `message` | text | Human-readable notification text |
+| `related_appointment_id` | uuid | FK → appointments (nullable) |
+| `status` | text | `'unread'` \| `'read'` \| `'dismissed'` (default `'unread'`) |
+| `read_at` | timestamptz | Set when status changes to read or dismissed |
+| `created_at` | timestamptz | Auto-set |
+
+**NOTE:** Notification generation is wrapped in a try/catch so that failures never prevent an appointment from being booked. If notification creation fails, the error is logged to the backend console but the appointment booking succeeds normally.
 
 ## Storage Setup
 NOTE: Must create a storage bucket in the Supabase Dashboard first:

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -21,6 +21,23 @@ CREATE TABLE public.alerts (
   CONSTRAINT alerts_check_in_id_fkey FOREIGN KEY (check_in_id) REFERENCES public.check_ins(id),
   CONSTRAINT alerts_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.questions(id)
 );
+CREATE TABLE public.appointments (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  provider_id uuid NOT NULL,
+  patient_id uuid NOT NULL,
+  start_at timestamp with time zone NOT NULL,
+  end_at timestamp with time zone NOT NULL,
+  status text NOT NULL DEFAULT 'scheduled'::text CHECK (status = ANY (ARRAY['scheduled'::text, 'cancelled'::text, 'completed'::text])),
+  reason text,
+  cancelled_at timestamp with time zone,
+  cancelled_by uuid,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT appointments_pkey PRIMARY KEY (id),
+  CONSTRAINT appointments_provider_id_fkey FOREIGN KEY (provider_id) REFERENCES public.profiles(id),
+  CONSTRAINT appointments_patient_id_fkey FOREIGN KEY (patient_id) REFERENCES public.profiles(id),
+  CONSTRAINT appointments_cancelled_by_fkey FOREIGN KEY (cancelled_by) REFERENCES public.profiles(id)
+);
 CREATE TABLE public.attachments (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   patient_id uuid NOT NULL,
@@ -57,6 +74,21 @@ CREATE TABLE public.check_ins (
   CONSTRAINT check_ins_pkey PRIMARY KEY (id),
   CONSTRAINT check_ins_patient_id_fkey FOREIGN KEY (patient_id) REFERENCES public.profiles(id)
 );
+CREATE TABLE public.notifications (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  recipient_id uuid NOT NULL,
+  sender_id uuid,
+  type text NOT NULL CHECK (type = ANY (ARRAY['appointment_booked'::text, 'appointment_cancelled'::text, 'appointment_rescheduled'::text])),
+  message text NOT NULL,
+  related_appointment_id uuid,
+  status text NOT NULL DEFAULT 'unread'::text CHECK (status = ANY (ARRAY['unread'::text, 'read'::text, 'dismissed'::text])),
+  read_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT notifications_pkey PRIMARY KEY (id),
+  CONSTRAINT notifications_recipient_id_fkey FOREIGN KEY (recipient_id) REFERENCES public.profiles(id),
+  CONSTRAINT notifications_sender_id_fkey FOREIGN KEY (sender_id) REFERENCES public.profiles(id),
+  CONSTRAINT notifications_related_appointment_id_fkey FOREIGN KEY (related_appointment_id) REFERENCES public.appointments(id)
+);
 CREATE TABLE public.patient_details (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   profile_id uuid NOT NULL UNIQUE,
@@ -92,6 +124,26 @@ CREATE TABLE public.profiles (
   CONSTRAINT profiles_pkey PRIMARY KEY (id),
   CONSTRAINT profiles_auth_user_id_fkey FOREIGN KEY (auth_user_id) REFERENCES auth.users(id)
 );
+CREATE TABLE public.provider_availability (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  provider_id uuid NOT NULL,
+  day_of_week smallint NOT NULL CHECK (day_of_week >= 0 AND day_of_week <= 6),
+  start_time time without time zone NOT NULL,
+  end_time time without time zone NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT provider_availability_pkey PRIMARY KEY (id),
+  CONSTRAINT provider_availability_provider_id_fkey FOREIGN KEY (provider_id) REFERENCES public.profiles(id)
+);
+CREATE TABLE public.provider_availability_exceptions (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  provider_id uuid NOT NULL,
+  start_at timestamp with time zone NOT NULL,
+  end_at timestamp with time zone NOT NULL,
+  reason text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT provider_availability_exceptions_pkey PRIMARY KEY (id),
+  CONSTRAINT provider_availability_exceptions_provider_id_fkey FOREIGN KEY (provider_id) REFERENCES public.profiles(id)
+);
 CREATE TABLE public.provider_details (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   profile_id uuid NOT NULL UNIQUE,
@@ -102,9 +154,9 @@ CREATE TABLE public.provider_details (
   clinic_address text,
   npi_number text,
   accepting_patients boolean DEFAULT true,
-  timezone text NOT NULL DEFAULT 'America/Chicago',
   updated_at timestamp with time zone NOT NULL DEFAULT now(),
   created_at timestamp with time zone NOT NULL DEFAULT now(),
+  timezone text NOT NULL DEFAULT 'America/Chicago'::text,
   CONSTRAINT provider_details_pkey PRIMARY KEY (id),
   CONSTRAINT provider_details_profile_id_fkey FOREIGN KEY (profile_id) REFERENCES public.profiles(id)
 );
@@ -131,47 +183,3 @@ CREATE TABLE public.questions (
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   CONSTRAINT questions_pkey PRIMARY KEY (id)
 );
-
-CREATE TABLE public.provider_availability (
-  id uuid NOT NULL DEFAULT gen_random_uuid(),
-  provider_id uuid NOT NULL,
-  day_of_week smallint NOT NULL CHECK (day_of_week BETWEEN 0 AND 6),
-  start_time time NOT NULL,
-  end_time time NOT NULL CHECK (end_time > start_time),
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  CONSTRAINT provider_availability_pkey PRIMARY KEY (id),
-  CONSTRAINT provider_availability_provider_fkey FOREIGN KEY (provider_id) REFERENCES public.profiles(id),
-  CONSTRAINT provider_availability_unique_slot UNIQUE (provider_id, day_of_week, start_time)
-);
-CREATE TABLE public.provider_availability_exceptions (
-  id uuid NOT NULL DEFAULT gen_random_uuid(),
-  provider_id uuid NOT NULL,
-  start_at timestamp with time zone NOT NULL,
-  end_at timestamp with time zone NOT NULL CHECK (end_at > start_at),
-  reason text,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  CONSTRAINT provider_availability_exceptions_pkey PRIMARY KEY (id),
-  CONSTRAINT provider_availability_exceptions_provider_fkey FOREIGN KEY (provider_id) REFERENCES public.profiles(id)
-);
-CREATE TABLE public.appointments (
-  id uuid NOT NULL DEFAULT gen_random_uuid(),
-  provider_id uuid NOT NULL,
-  patient_id uuid NOT NULL,
-  start_at timestamp with time zone NOT NULL,
-  end_at timestamp with time zone NOT NULL CHECK (end_at = start_at + interval '1 hour'),
-  status text NOT NULL DEFAULT 'scheduled'
-         CHECK (status IN ('scheduled','cancelled','completed')),
-  reason text,
-  cancelled_at timestamp with time zone,
-  cancelled_by uuid,
-  created_at timestamp with time zone NOT NULL DEFAULT now(),
-  updated_at timestamp with time zone NOT NULL DEFAULT now(),
-  CONSTRAINT appointments_pkey PRIMARY KEY (id),
-  CONSTRAINT appointments_provider_fkey FOREIGN KEY (provider_id) REFERENCES public.profiles(id),
-  CONSTRAINT appointments_patient_fkey FOREIGN KEY (patient_id) REFERENCES public.profiles(id),
-  CONSTRAINT appointments_cancelled_by_fkey FOREIGN KEY (cancelled_by) REFERENCES public.profiles(id)
-);
--- Prevents double-booking at the DB level:
-CREATE UNIQUE INDEX appointments_unique_scheduled_slot
-  ON public.appointments (provider_id, start_at)
-  WHERE status = 'scheduled';


### PR DESCRIPTION
…appointment

- Created a notification table in Supabase, service, controller, and route
- Auto-generate the notification to the provider when an appointment is booked
- The notification includes the patient name and time
- It is wrapped in a try-catch to try and properly deal with a notification failing so it does not block the booking
- The following notification endpoints were added: list, unread, mark read, and mark all read
- Updated the api-reference.md and database-schema.md documentation